### PR TITLE
Fix the package requirements for Fedora

### DIFF
--- a/getting-started/installation/README.md
+++ b/getting-started/installation/README.md
@@ -160,6 +160,22 @@ After installing all dependencies, you can proceed building.
 If you don't already have a development environment setup, run the following:
 
 ```bash
+$ yum install -y @development-tools
+```
+
+Install development headers and tools:
+
+```bash
+$ yum install -y cmake git mariadb-devel zlib-devel
+```
+
+After installing all dependencies, you can proceed building.
+{% endtab %}
+
+{% tab title="openSUSE" %}
+If you don't already have a development environment setup, run the following:
+
+```bash
 $ yum groupinstall -y development
 ```
 


### PR DESCRIPTION
I'm not sure why MariaDB-client was added here, because it's not a valid package on Fedora. However, it *is* a package name on openSUSE so I moved it to it's own tab. Additionally, mariadb-client is the name of the required package on Fedora - not libmariadb-devel (that's also openSUSE.)

The name of the development-tools group is also wrong, it's development-tools and newer DNF doesn't support groupinstall.